### PR TITLE
chore: Python 프로젝트 표준 .gitignore 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,63 @@
+# Python - Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+*.pyo
+*.pyd
+
+# Python - Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+.eggs/
+MANIFEST
+wheels/
+share/python-wheels/
+
+# Python - Virtual environments
+venv/
+.venv/
+env/
+.env/
+ENV/
+env.bak/
+venv.bak/
+
+# Python - Testing
+.pytest_cache/
+.tox/
+.nox/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+*.cover
+*.py,cover
+nosetests.xml
+test-results/
+
+# Python - Type checking
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pytype/
+.pyre/
+
+# Python - Jupyter Notebook
+.ipynb_checkpoints
+*.ipynb_checkpoints/
+
+# Python - Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Python - Unit test / coverage reports
+.hypothesis/
+
+# Python - pyenv
+.python-version
+
 # Environment
 .env
 .env.*


### PR DESCRIPTION
- Python 바이트 파일, 패키징, 가상환경 관련 파일 제외
- 테스트 캐시, 타입 체킹, Jupyter 등 개발 도구 파일 제외
- IDE(JetBrains, VSCode), OS 파일, 환경변수 파일 제외

close #1