### PR TITLE
chore: ruff 린터 설정 파일 추가

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,31 @@
+# Ruff 설정 파일
+# https://docs.astral.sh/ruff/configuration/
+
+line-length = 120
+target-version = "py310"
+
+[lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "N",   # pep8-naming
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "SIM", # flake8-simplify
+    "RUF", # ruff-specific rules
+]
+ignore = [
+    "E501", # line-length는 formatter에 위임
+]
+
+[lint.isort]
+known-first-party = ["src"]
+
+[format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"
+skip-magic-trailing-comma = true


### PR DESCRIPTION
- lint 규칙: E, W, F, I, N, UP, B, C4, SIM, RUF 활성화
- isort: src/ 하위 모듈을 first-party로 지정
- format: double quote, space indent, trailing comma 무시

close #3