### PR TITLE
chore: lefthook pre-commit에 pytest 테스트 잡 추가

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,18 @@
+pre-commit:
+  parallel: false
+  jobs:
+    - name: ruff-lint
+      glob: "*.py"
+      run: uv run ruff check {staged_files}
+
+    - name: ruff-format
+      glob: "*.py"
+      run: uv run ruff format --check {staged_files}
+
+    - name: bandit
+      glob: "*.py"
+      run: uv run bandit -q {staged_files}
+
+    - name: test
+      glob: "*.py"
+      run: uv run pytest --no-cov -n auto -q --no-header


### PR DESCRIPTION
- test 잡 추가: uv run pytest --no-cov -n auto -q --no-header
- --no-cov: 커버리지 측정 생략으로 실행 속도 향상
- -n auto: pytest-xdist 병렬 실행 (CPU 코어 수 자동)
- -q / --no-header: 불필요한 출력 최소화

close #27