### PR TITLE
chore: lefthook pre-commit test 잡 staged 파일만 실행하도록 수정

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,5 +14,5 @@ pre-commit:
       run: uv run bandit -q {staged_files}
 
     - name: test
-      glob: "*.py"
-      run: uv run pytest --no-cov -n auto -q --no-header
+      glob: "tests/**/test_*.py"
+      run: uv run pytest {staged_files} --no-cov -n auto -q --no-header


### PR DESCRIPTION
- glob을 tests/test_*.py로 변경해 테스트 파일 미staged 시 잡 스킵
- {staged_files}로 staged된 테스트 파일만 pytest에 전달

close #31