### PR TITLE
chore: bandit pre-commit hook glob을 src/**/*.py로 수정

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,7 +10,7 @@ pre-commit:
       run: uv run ruff format --check {staged_files}
 
     - name: bandit
-      glob: "*.py"
+      glob: "src/**/*.py"
       run: uv run bandit -q {staged_files}
 
     - name: test


### PR DESCRIPTION
- 기존 *.py glob은 src 외부 파일도 bandit 검사 대상에 포함
- src/**/*.py로 변경하여 소스 코드 디렉토리만 검사하도록 한정

close #50