### PR TITLE
fix: JSONRenderer에 ensure_ascii=False 적용하여 한글 유니코드 이스케이프 문제 수정

### DIFF
--- a/src/monitoring/logger.py
+++ b/src/monitoring/logger.py
@@ -1,5 +1,7 @@
+import json
 import logging
 import sys
+from functools import partial
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -39,7 +41,7 @@ class StructuredLogger:
         if output_type == "console":
             return structlog.dev.ConsoleRenderer(colors=True)
         if self.config.get("format") == "json":
-            return structlog.processors.JSONRenderer()
+            return structlog.processors.JSONRenderer(serializer=partial(json.dumps, ensure_ascii=False))
         return structlog.dev.ConsoleRenderer(colors=False)
 
     def setup_logging(self):

--- a/tests/monitoring/test_logger.py
+++ b/tests/monitoring/test_logger.py
@@ -263,6 +263,16 @@ def test_get_renderer_file_text_returns_console_renderer(tmp_path):
     assert isinstance(logger._get_renderer("file"), structlog.dev.ConsoleRenderer)
 
 
+@pytest.mark.unit
+def test_json_renderer_does_not_escape_korean(tmp_path):
+    """JSONRenderer가 한글을 \\uXXXX로 이스케이프하지 않고 그대로 직렬화한다."""
+    logger = StructuredLogger(name="app", config={"log_dir": str(tmp_path), "format": "json"})
+    renderer = logger._get_renderer("file")
+    result = renderer(None, None, {"event": "한글 테스트"})
+    assert "한글 테스트" in result
+    assert "\\u" not in result
+
+
 # ---------------------------------------------------------------------------
 # File handler
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
json.dumps의 ensure_ascii 기본값(True)으로 인해 한글이 \uXXXX로

이스케이프되던 버그를 수정. partial(json.dumps, ensure_ascii=False)을

serializer로 지정하여 한글이 그대로 직렬화되도록 함.

fix #63