### PR TITLE
feat: Loki 설정 추가

### DIFF
--- a/config/loki/config.yml
+++ b/config/loki/config.yml
@@ -1,0 +1,37 @@
+# Loki 설정 — 로컬 개발용 단일 노드 구성
+# 인증 없이 동작하며 로그를 로컬 파일시스템에 저장한다.
+
+auth_enabled: false
+
+server:
+  http_listen_port: ${LOKI_PORT:-3100}
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      # 청크(실제 로그 데이터) 저장 경로
+      chunks_directory: /loki/chunks
+      # 알림 규칙 저장 경로
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      # 단일 노드이므로 인메모리 KV 스토어 사용
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h  # 인덱스를 하루 단위로 분할
+
+limits_config:
+  # 오래된 샘플 거부 (7일 초과 타임스탬프)
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h


### PR DESCRIPTION
- 로컬 개발용 단일 노드 구성 (auth_enabled: false)
- LOKI_PORT 환경변수로 포트 주입, 기본값 3100

close #40