### PR TITLE
feat: Grafana Loki 데이터소스 프로비저닝 설정 추가

### DIFF
--- a/config/grafana/provisioning/datasources/loki.yml
+++ b/config/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,12 @@
+# Grafana 데이터소스 자동 프로비저닝 — Loki 연결 설정
+# Grafana 시작 시 자동으로 Loki 데이터소스를 등록한다.
+
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:${LOKI_PORT}
+    isDefault: true
+    editable: false


### PR DESCRIPTION
- Grafana 시작 시 Loki 데이터소스 자동 등록
- LOKI_PORT 환경변수로 포트 주입, 기본값 3100

close #43