### PR TITLE
fix: Alloy config.alloy path_targets trailing comma 문법 오류 수정

### DIFF
--- a/config/alloy/config.alloy
+++ b/config/alloy/config.alloy
@@ -3,7 +3,7 @@
 
 // 1. 로그 파일 탐색
 local.file_match "local_files" {
-  path_targets = [{__path__ = "/var/log/app/*.log"}],
+  path_targets = [{__path__ = "/var/log/app/*.log"}]
   sync_period = "5s"
 }
 


### PR DESCRIPTION
- local.file_match 블록의 path_targets 속성 끝에 불필요한 trailing comma가 있어 Alloy가 파싱 오류(expected TERMINATOR, got ,)로 시작 실패하는 문제 수정

closes #70