### PR TITLE
fix: Loki 내부 포트 하드코딩으로 고정

### DIFF
--- a/config/loki/config.yml
+++ b/config/loki/config.yml
@@ -4,7 +4,7 @@
 auth_enabled: false
 
 server:
-  http_listen_port: ${LOKI_PORT:-3100}
+  http_listen_port: 3100
 
 common:
   instance_addr: 127.0.0.1


### PR DESCRIPTION
LOKI_PORT 환경변수로 내부 포트를 동적으로 제어하던 방식에서
Alloy, Grafana와 동일하게 내부 포트를 3100으로 고정
- config.yml http_listen_port: ${LOKI_PORT:-3100} → 3100
- LOKI_PORT는 호스트 포트 매핑에만 사용

close #75