### PR TITLE
fix: Loki 내부 통신 포트 하드코딩으로 LOKI_PORT 이중 사용 제거

### DIFF
--- a/config/alloy/config.alloy
+++ b/config/alloy/config.alloy
@@ -44,9 +44,9 @@ loki.process "parse_json" {
 }
 
 // Loki 엔드포인트 (컨테이너 내부에서는 Docker 서비스명으로 접근)
-// LOKI_PORT 환경변수로 포트를 주입한다. 기본값은 3100.
+// 내부 통신은 Loki 고정 포트 3100 사용
 loki.write "grafana_loki" {
   endpoint {
-    url = "http://loki:" + coalesce(env("LOKI_PORT"), "3100") + "/loki/api/v1/push"
+    url = "http://loki:3100/loki/api/v1/push"
   }
 }

--- a/config/grafana/provisioning/datasources/loki.yml
+++ b/config/grafana/provisioning/datasources/loki.yml
@@ -7,6 +7,6 @@ datasources:
   - name: Loki
     type: loki
     access: proxy
-    url: http://loki:${LOKI_PORT}
+    url: http://loki:3100
     isDefault: true
     editable: false


### PR DESCRIPTION
LOKI_PORT가 호스트 포트와 내부 통신 포트로 이중 사용되어
호스트 포트 변경 시 Alloy/Grafana 연결이 실패하는 문제 수정
- config/alloy/config.alloy: env("LOKI_PORT") → 3100 고정
- config/grafana/provisioning/datasources/loki.yml: ${LOKI_PORT} → 3100 고정

fix #77